### PR TITLE
Bump outdated bounds

### DIFF
--- a/free-theorems/free-theorems.cabal
+++ b/free-theorems/free-theorems.cabal
@@ -39,7 +39,7 @@ test-suite runtests
       base
     , containers >= 0.1.0.1
     , haskell-src >= 1.0
-    , haskell-src-exts >= 1.21 && < 1.22
+    , haskell-src-exts >= 1.21 && < 1.24
     , mtl >= 2.2.1
     , pretty >= 1.0.0.0
     , syb >= 0.1.0.0
@@ -61,7 +61,7 @@ library
       base >= 4.12 && < 5
     , containers >= 0.1.0.1
     , haskell-src >= 1.0
-    , haskell-src-exts >= 1.21 && < 1.22
+    , haskell-src-exts >= 1.21 && < 1.24
     , mtl >= 2.2.1
     , pretty >= 1.0.0.0
     , syb >= 0.1.0.0

--- a/free-theorems/src/Language/Haskell/FreeTheorems/Parser/Hsx.hs
+++ b/free-theorems/src/Language/Haskell/FreeTheorems/Parser/Hsx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Language.Haskell.FreeTheorems.Parser.Hsx (parse) where
@@ -358,12 +359,22 @@ mkContext cx = case cx of
     (CxEmpty _)    -> return []
 
     where
+#if MIN_VERSION_haskell_src_exts(1,22,0)
+      trans (TypeA _ (TyApp _ (TyCon _ qname) (TyVar _ var))) = do
+#else
       trans (ClassA _ qname [TyVar _ var]) = do
+#endif
         ident <- liftM S.TC (mkIdentifierQ qname)
         tv    <- mkTypeVariable var
         return $ (ident, tv)
 
-      trans (ClassA _ _ _) = throwError errContext
+#if MIN_VERSION_haskell_src_exts(1,22,0)
+      trans (TypeA _ _) =
+#else
+      trans (ClassA _ _ _) =
+#endif
+        throwError errContext
+
       trans (IParam _ _ _) = throwError errImplicit
 
 errContext =


### PR DESCRIPTION
This looks like the correct change to me looking at the new types and upstream's [own migration](https://github.com/haskell-suite/haskell-src-exts/commit/c1a6ad50dad44cf93a8972b13cdf78673277cddd#diff-3dbd0da10b59c15628819bc3fbb86d5ccb9e71a4f7b8d6a6b41ef322dd0b86dfL207) but I couldn't find out how to load in a browser to test properly. I always get a 404 page and the logs show
```
127.0.0.1 - - [23/Feb/2025 20:27:37] code 404, message No such CGI script ('/')
127.0.0.1 - - [23/Feb/2025 20:27:37] "GET / HTTP/1.1" 404 -
```
The test suite passes but that still happens even with `mkContext = undefined` so this isn't currently covered

https://www-ps.informatik.uni-kiel.de/~sad/FreeTheorems/cgi-bin/free-theorems-webui.cgi is also down so I can't easily confirm what the current behavior is

